### PR TITLE
TST: fix spelling of fluor_yield in tests

### DIFF
--- a/python/tests/test_xray.py
+++ b/python/tests/test_xray.py
@@ -11,7 +11,7 @@ from xraydb import (chemparse, material_mu, material_mu_components,
                     mu_chantler, mu_elam, coherent_cross_section_elam,
                     incoherent_cross_section_elam, atomic_number,
                     atomic_symbol, atomic_mass, atomic_density, xray_edges,
-                    xray_edge, xray_lines, xray_line, fluo_yield,
+                    xray_edge, xray_lines, xray_line, fluor_yield,
                     ck_probability, core_width, guess_edge,
                     xray_delta_beta, XrayDB)
 


### PR DESCRIPTION
Initially observed in https://github.com/nsls-ii-forge/xraydb-feedstock/pull/1 via https://github.com/nsls-ii-forge/xraydb-feedstock/pull/1/commits/7090da6eaeba589a171ac8bbc8082a802eceaaf1.

Before the fix:
```py
(xraydb) ✔ ~/src/mrakitin/open-source/XrayDB/python/tests [master|✔]
15:51 $ pytest -vvvv test_xray.py
================================================================================================ test session starts ================================================================================================
platform darwin -- Python 3.7.4, pytest-5.0.1, py-1.8.0, pluggy-0.12.0 -- /miniconda3/envs/xraydb/bin/python
cachedir: .pytest_cache
rootdir: /Users/mrakitin/src/mrakitin/open-source/XrayDB/python
collected 0 items / 1 errors

====================================================================================================== ERRORS =======================================================================================================
________________________________________________________________________________________ ERROR collecting tests/test_xray.py ________________________________________________________________________________________
ImportError while importing test module '/Users/mrakitin/src/mrakitin/open-source/XrayDB/python/tests/test_xray.py'.
Hint: make sure your test modules/packages have valid Python names.
Traceback:
/miniconda3/envs/xraydb/lib/python3.7/site-packages/_pytest/python.py:498: in _importtestmodule
    mod = self.fspath.pyimport(ensuresyspath=importmode)
/miniconda3/envs/xraydb/lib/python3.7/site-packages/py/_path/local.py:701: in pyimport
    __import__(modname)
/miniconda3/envs/xraydb/lib/python3.7/site-packages/_pytest/assertion/rewrite.py:149: in exec_module
    exec(co, module.__dict__)
test_xray.py:8: in <module>
    from xraydb import (chemparse, material_mu, material_mu_components,
E   ImportError: cannot import name 'fluo_yield' from 'xraydb' (/Users/mrakitin/src/mrakitin/open-source/XrayDB/python/xraydb/__init__.py)
!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! Interrupted: 1 errors during collection !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
============================================================================================== 1 error in 0.62 seconds ==============================================================================================
```

After the fix:
```py
(xraydb) ✔ ~/src/mrakitin/open-source/XrayDB/python/tests [master|✚ 1]
15:51 $ pytest -vvvv test_xray.py
================================================================================================ test session starts ================================================================================================
platform darwin -- Python 3.7.4, pytest-5.0.1, py-1.8.0, pluggy-0.12.0 -- /miniconda3/envs/xraydb/bin/python
cachedir: .pytest_cache
rootdir: /Users/mrakitin/src/mrakitin/open-source/XrayDB/python
collected 4 items

test_xray.py::test_chemparse PASSED                                                                                                                                                                           [ 25%]
test_xray.py::test_atomic_data PASSED                                                                                                                                                                         [ 50%]
test_xray.py::test_edge_energies PASSED                                                                                                                                                                       [ 75%]
test_xray.py::test_emission_lines PASSED                                                                                                                                                                      [100%]

============================================================================================= 4 passed in 0.98 seconds ==============================================================================================
```