### PR TITLE
fix length unit in doc string of ionchamber_fluxes

### DIFF
--- a/doc/examples.rst
+++ b/doc/examples.rst
@@ -252,7 +252,7 @@ associated with an ion chamber and help handle all of these subtle issues,
 using the following inputs:
 
   * `gas`: the gas, or mixture of gases used or 'Si' or 'Ge' for diodes.
-  * `length`: the length of the ion chamber, in mm.
+  * `length`: the length of the ion chamber, in cm.
   * `energy`: the X-ray energy, in eV.
   * `volts`: the output voltage of the current amplifier
   * `sensitivity` and `sensitivity_units`: the sensitivity or gain of the

--- a/python/xraydb/xray.py
+++ b/python/xraydb/xray.py
@@ -816,7 +816,7 @@ def ionchamber_fluxes(gas='nitrogen', volts=1.0, length=100.0,
     Args:
         gas (string or dict):  name or formula of fill gas (see note 1) ['nitrogen']
         volts (float):  measured voltage output of current amplifier  [1.0]
-        length (float): active length of ion chamber in mm [100]
+        length (float): active length of ion chamber in cm [100]
         energy (float): X-ray energy in eV [10000]
         sensitivity (float): current amplifier sensitivity [1.e-6]
         sensitivity_units (string): units of current amplifier sensitivity


### PR DESCRIPTION
In the doc string of the ionchamber_fluxes function, if the length scale is modified from mm to cm, it seems to give the correct result.