### PR TITLE
Implement missing functionality of the `categories` argument in call to get_materials()

### DIFF
--- a/python/xraydb/materials.py
+++ b/python/xraydb/materials.py
@@ -249,7 +249,7 @@ def get_materials(force_read=False, categories=None):
         _materials = _read_materials_db()
     if categories is not None:
         if not type(categories) is list:
-            categories = list(categories)
+            categories = list([categories])
         filtered_materials = {
             k: v for k,v in _materials.items() if
             (set(v.categories) & set(categories))

--- a/python/xraydb/materials.py
+++ b/python/xraydb/materials.py
@@ -247,7 +247,16 @@ def get_materials(force_read=False, categories=None):
 
     if force_read or _materials is None:
         _materials = _read_materials_db()
-    return _materials
+    if categories is not None:
+        if not type(categories) is list:
+            categories = list(categories)
+        filtered_materials = {
+            k: v for k,v in _materials.items() if
+            (set(v.categories) & set(categories))
+        }
+        return filtered_materials
+    else:    
+        return _materials
 
 
 def add_material(name, formula, density, categories=None):


### PR DESCRIPTION
The optional argument `categories` was never used in the call to get_materials(), filtering was thus not implemented. Added code to return the dictionary restricted to materials belonging to the specified categories.

P.S.: Thanks for creating and maintaining such a great library!