### PR TITLE
Add transmission mode sample analysis functions

### DIFF
--- a/python/xraydb/__init__.py
+++ b/python/xraydb/__init__.py
@@ -25,7 +25,7 @@ from .xray import (atomic_number, atomic_symbol, atomic_mass,
                    incoherent_cross_section_elam, guess_edge,
                    xray_delta_beta, get_xraydb, darwin_width,
                    mirror_reflectivity, ionchamber_fluxes,
-                   ionization_potential)
+                   ionization_potential, transmission_sample)
 
 from ._version import get_versions
 __version__ = get_versions()['version']

--- a/python/xraydb/xray.py
+++ b/python/xraydb/xray.py
@@ -1139,7 +1139,7 @@ def darwin_width(energy, crystal='Si', hkl=(1, 1, 1), a=None,
                        intensity=abs(r*r.conjugate()))
 
 
-def transmission_sample(sample, energy, absorp_total=2.6, area=None, 
+def transmission_sample(sample, energy, absorp_total=2.6, area=1, 
                         density=None, frac_type='mass'):
     """Analyze transmission mode sample. Sample can be specified as a chemical
     formula (str or dict) or as mass fractions (dict). One mass fraction can 
@@ -1157,7 +1157,7 @@ def transmission_sample(sample, energy, absorp_total=2.6, area=None,
         energy (float): X-ray energy (eV) at which transmission will be analyzed
         absorp_total (float): total absorption (mu_t*d) of the sample at the
                               specified energy
-        area (float)(optional): area (cm^2) of the sample
+        area (float)(optional): area (cm^2) of the sample. Default is 1 cm^2.
         density (float)(optional): density (g/cm^3) of the sample
         frac_type (str)(optional): can be `mass` or `molar`, if sample is dict, 
                                    this keyword specifies whether the indicated 

--- a/python/xraydb/xray.py
+++ b/python/xraydb/xray.py
@@ -1126,3 +1126,268 @@ def darwin_width(energy, crystal='Si', hkl=(1, 1, 1), a=None,
                        dtheta=zeta*np.tan(theta),
                        denergy=-zeta*energy,
                        intensity=abs(r*r.conjugate()))
+
+
+def analyze_transmission_sample_from_mass_fracs(mass_fracs, energy, 
+                                                absorp_total=2.6, area=None, 
+                                                density=None):
+    """Analyze transmission mode sample from mass fractions. Mass fractions
+    can be specified by element or compound. One mass fraction can have value 
+    -1 to indicate the unspecified portion of the mass fractions (i.e. so 
+    that sum is made to equal one).
+
+    Args:
+        mass_fracs (dict): elements/compounds and their mass fractions. one 
+                           entry can have value -1 to indicate unspecified portion
+        energy (float): X-ray energy (eV) at which transmission will be analyzed
+        absorp_total (float): total absorption (mu_t*d) of the sample at the
+                              specified energy
+        area (float)(optional): area (cm^2) of the sample
+        density (float)(optional): density (g/cm^3) of the sample
+
+    Returns:
+        dictionary with fields
+
+            `energy(eV)`        incident energy
+
+            `absorp_total`      total absorption
+
+            `mass_fractions`    mass fractions of elements
+
+            `absorbance_steps`  absorbance steps of each element in the sample
+
+            `area (cm^2)`       area, if specified
+
+            `mass_total(mg)`    total mass of sample (if area specified)
+
+            `mass_components(mg)`   mass of each element (if area specified)
+
+            `density(g/cc)`     density, if specified
+
+            `thickness(mm)`     thickness of sample (if area AND density specified)
+
+            `absorption_length(um)` abs. length of sample (if area AND density specified)
+
+    Examples:
+
+        5% Fe in Silica
+        >>> analyze_transmission_sample_from_mass_fracs(
+                mass_fracs={'Fe': 0.05, 'SiO2': -1},
+                energy=xraydb.xray_edge('Fe', 'K').energy + 50,
+                area=1.33
+            )
+        
+        {'absorbance_steps': {'Fe': 0.6692395733146204,
+                            'O': 3.386553723091669e-07,
+                            'Si': 1.297403071978392e-06},
+        'absorp_total': 2.6,
+        'absorption_length(um)': None,
+        'area(cm^2)': 1.33,
+        'density(g/cc)': None,
+        'energy(eV)': 7162.0,
+        'mass_components(mg)': {'Fe': 2.552976845244654,
+                                'O': 25.832813088371587,
+                                'Si': 22.673746971276834},
+        'mass_fractions': {'Fe': 0.05,
+                            'O': 0.5059351230797396,
+                            'Si': 0.4440648769202603},
+        'mass_total(mg)': 51.05953690489308,
+        'thickness(mm)': None}
+    """
+    mass_fracs = _validate_mass_fracs(mass_fracs)
+    mu_tot = sum([mu_elam(k, energy) * v for k, v in mass_fracs.items()])
+    rho_d = absorp_total / mu_tot
+
+    absorbance_steps = {}
+    pre_edge = np.linspace(energy - 200, energy - 50, 100)
+    for el in mass_fracs.keys():
+        coeffs = np.polyfit(pre_edge, mu_elam(el, pre_edge), 3)
+        extrapolated = sum([c * energy ** (len(coeffs) - 1 - i) \
+                            for i, c in enumerate(coeffs)])
+        post_edge = mu_elam(el, energy)
+        absorbance_steps[el] = (post_edge - extrapolated) * mass_fracs[el] * rho_d
+
+    results = {}
+    results['energy(eV)'] = energy
+    results['absorp_total'] = absorp_total
+    results['mass_fractions'] = mass_fracs
+    results['absorbance_steps'] = absorbance_steps
+
+    results['area(cm^2)'] = None
+    results['mass_total(mg)'] = None
+    results['mass_components(mg)'] = None
+    results['density(g/cc)'] = None
+    results['thickness(mm)'] = None
+    results['absorption_length(um)'] = None
+
+    if area:
+        results['area(cm^2)'] = area
+        mass_total = rho_d * area * 1000 # mg
+        results['mass_total(mg)'] = mass_total
+        results['mass_components(mg)'] = {k: v * mass_total for k, v in mass_fracs.items()}
+        if density:
+            results['density(g/cc)'] = density
+            results['thickness(mm)'] = mass_total / (area * 100) / density
+            results['absorption_length(um)'] = 1 / density / mu_tot * 1e4
+
+    return results
+
+
+def analyze_transmission_sample_from_formula(formula, energy, absorp_total=2.6, 
+                                    area=None, density=None):
+    """Analyze transmission mode sample from molecular formula.
+
+    Args:
+        formula (str or dict): chemical formula
+        energy (float): X-ray energy (eV) at which transmission will be analyzed
+        absorp_total (float): total absorption (mu_t*d) of the sample at the
+                              specified energy
+        area (float)(optional): area (cm^2) of the sample
+        density (float)(optional): density (g/cm^3) of the sample
+
+    Returns:
+        dictionary with fields
+
+            `energy(eV)`        incident energy
+
+            `absorp_total`      total absorption
+
+            `mass_fractions`    mass fractions of elements
+
+            `absorbance_steps`  absorbance steps of each element in the sample
+
+            `area (cm^2)`       area, if specified
+
+            `mass_total(mg)`    total mass of sample (if area specified)
+
+            `mass_components(mg)`   mass of each element (if area specified)
+
+            `density(g/cc)`     density, if specified
+
+            `thickness(mm)`     thickness of sample (if area AND density specified)
+
+            `absorption_length(um)` abs. length of sample (if area AND density specified)
+
+    Examples:
+
+        >>> analyze_transmission_sample_from_formula(
+                formula='Fe2O3',
+                energy=xraydb.xray_edge('Fe', 'K').energy + 50,
+                area=1.33
+            )
+        {'absorbance_steps': {'Fe': 2.2227981005407176, 'O': 4.7769571901536886e-08},
+        'absorp_total': 2.6,
+        'absorption_length(um)': None,
+        'area(cm^2)': 1.33,
+        'density(g/cc)': None,
+        'energy(eV)': 7162.0,
+        'mass_components(mg)': {'Fe': 8.479403054765946, 'O': 3.643888516604898},
+        'mass_fractions': {'Fe': 0.6994307614270416, 'O': 0.3005692385729583},
+        'mass_total(mg)': 12.123291571370844,
+        'thickness(mm)': None}
+
+        OR
+
+        >>> analyze_transmission_sample_from_formula(
+                formula={'Fe': 2, 'O': 3},
+                energy=xraydb.xray_edge('Fe', 'K').energy + 50,
+                area=1.33
+            )
+        Output same as previous example
+    """
+    mass_fracs = formula_to_mass_fracs(formula)
+    return analyze_transmission_sample_from_mass_fracs(
+                mass_fracs=mass_fracs,
+                energy=energy,
+                absorp_total=absorp_total,
+                area=area,
+                density=density,
+                )
+
+
+def formula_to_mass_fracs(formula):
+    """Calculate mass fractions of elements from a given molecular formula.
+
+    Args:
+        formula (str or dict): chemical formula
+    
+    Returns:
+        dict with fields of each element and values of their mass fractions
+
+    Example:
+        >>> formula_to_mass_fracs('Fe2O3')
+        {'Fe': 0.6994307614270416, 'O': 0.3005692385729583}
+
+        >>> formula_to_mass_fracs({'Fe': 2, 'O': 3})
+        {'Fe': 0.6994307614270416, 'O': 0.3005692385729583}
+    """
+    if type(formula) is str:
+        simplified_formula = chemparse(formula)
+    elif type(formula) is dict:
+        simplified_formula = {}
+        for k, v in formula.items():
+            elements = chemparse(k) # handle case of compound formula, e.g. {'Mn':1, 'SiO2':3}
+            elements = {el : c * v for el, c in elements.items()}
+            for el, c in elements.items():
+                if el in simplified_formula:
+                    simplified_formula[el] += c
+                else:
+                    simplified_formula[el] = c
+    else:
+        raise ValueError('`formula` must have type `str` or `dict`')
+    mol_weight = sum([v * atomic_mass(k) for k, v in simplified_formula.items()])
+    mass_fracs = {k: v * atomic_mass(k) / mol_weight for k, v in simplified_formula.items()}
+    return mass_fracs
+
+
+def mass_fracs_to_formula(mass_fracs):
+    """Calculate molecular formula from a given  mass fractions of elements.
+
+    Args:
+        mass_fracs (dict): mass fractions of elements
+    
+    Returns:
+        dict with fields of each element and values of their coefficients
+
+    Example:
+        >>> mass_fracs_to_formula({'Fe': 0.7, 'SiO2': -1})
+        {
+            'Fe': 0.012534694242994, 
+            'Si': 0.004993092888171364, 
+            'O': 0.009986185776342726
+        }
+    """
+    mass_fracs = _validate_mass_fracs(mass_fracs)
+    masses = {}
+    for el, _ in mass_fracs.items():
+        parsed = chemparse(el)
+        masses[el] = sum([atomic_mass(el) * c for el, c in parsed.items()])
+
+    coeffs = {k: mass_fracs[k] / masses[k] for k in mass_fracs.keys()}
+
+    return coeffs
+
+
+def _validate_mass_fracs(mass_fracs):
+    """Validate mass fractions. Either verify they sum to one, or calculate
+    the remaining portion of a compound/element with value specified as -1.
+
+    Additionally, compounds specified in mass_fracs will be separated to the
+    individual elements.
+    """
+    if any([v == -1 for v in mass_fracs.values()]):
+        unknown = [k for k, v in mass_fracs.items() if v == -1]
+        assert len(unknown) == 1, 'Multiple unknown weight percentages'
+        mass_fracs[unknown[0]] = 1 - sum({k:v for k, v in mass_fracs.items() if k != unknown[0]}.values())
+    else:
+        compare = abs(sum([v for v in mass_fracs.values()]) - 1) < 1e-4
+        if not compare:
+            raise RuntimeError("Mass fractions do not add up to one.")
+    
+    simplified_mass_fracs = {}
+    for comp, frac in mass_fracs.items():
+        parsed = chemparse(comp)
+        parsed_sum = sum([atomic_mass(el) * c for el, c in parsed.items()])
+        for el, c in parsed.items():
+            simplified_mass_fracs[el] = atomic_mass(el) * c / parsed_sum * frac
+    return simplified_mass_fracs


### PR DESCRIPTION
I considered a while breaking these functions into smaller pieces, but decided to just have all of the calculations done at once and then the user can pull what parts they want from the results. Happy to reorganize based on feedback.

Tried to stick to a consistent style guide and match docstring formats to the existing package. 

Realizing as I'm writing this that I might want a little more explanation in the docstring about how the absorbance steps for each element are calculated. This is done by performing a polynomial fit to the pre-edge absorption (from -200 to -50 eV, hard-coded) and extrapolating that to the post-edge, then comparing against the actual computed post-edge absorption.

I thought about putting `formula_to_mass_fracs` and `mass_fracs_to_formula` in the `chemparser.py` module, but for now put everything in `xray.py`. 

For comparison to Hephaestus, I ran a few examples and uses this test code to validate:
```python
def test_against_hephaestus():
    results = analyze_transmission_sample_from_formula(
        formula='Fe2O3',
        energy=7162,
        absorp_total=1,
        area=1,
        density=5.24
    )
    assert abs(results['mass_total(mg)'] - 3.506) < 1e-3, f"Fe2O3 mass at 7162 eV from Hephaestus should be 3.506 mg, calculated {results['mass_total(mg)']} instead."
    assert abs(results['absorption_length(um)'] - 6.7) < 1e-1, f"Fe2O3 absorption length at 7162 eV from Hephaestus should be 6.7um, calculated {results['absorption_length(um)']} instead."

    results = analyze_transmission_sample_from_formula(
        formula='Cu',
        energy=9029,
        absorp_total=1,
        area=1,
        density=8.94,
    )
    assert abs(results['mass_total(mg)'] - 3.640) < 1e-3, f"Cu mass at 9029 eV from Hephaestus should be 3.640 mg, calculated {results['mass_total(mg)']} instead."
    assert abs(results['absorption_length(um)'] - 4.1) < 1e-1, f"Cu absorption length at 9029 eV from Hephaestus should be 4.1um, calculated {results['absorption_length(um)']} instead."
```
![hephaestus example](https://user-images.githubusercontent.com/59660036/118331999-42a7a100-b4be-11eb-8ef4-7c1c0a48a123.png)

For comparison to XAFSmass, here is a quick validation:
```python
analyze_transmission_sample_from_mass_fracs(
        mass_fracs={'Fe': 0.05, 'SiO2': -1},
        energy=xraydb.xray_edge('Fe', 'K').energy + 50,
        area=1.33,
        density=2.65
    )

{'absorbance_steps': {'Fe': 0.6692395733146204,
                      'O': 3.386553723091669e-07,
                      'Si': 1.297403071978392e-06},
 'absorp_total': 2.6,
 'absorption_length(um)': 55.71934579361293,
 'area(cm^2)': 1.33,
 'density(g/cc)': 2.65,
 'energy(eV)': 7162.0,
 'mass_components(mg)': {'Fe': 2.552976845244654,
                         'O': 25.832813088371587,
                         'Si': 22.673746971276834},
 'mass_fractions': {'Fe': 0.05,
                    'O': 0.5059351230797396,
                    'Si': 0.4440648769202603},
 'mass_total(mg)': 51.05953690489308,
 'thickness(mm)': 0.14487029906339363}
```
![xfasmass_example](https://user-images.githubusercontent.com/59660036/118332657-4982e380-b4bf-11eb-9d2a-61b4c563c3c4.png)

