### PR TITLE
Transmission sample update energy docstring and absorbance step inter…

### DIFF
--- a/python/xraydb/xray.py
+++ b/python/xraydb/xray.py
@@ -1146,14 +1146,16 @@ def transmission_sample(sample, energy, absorp_total=2.6, area=1,
     (i.e. so made to equal one).
 
     Absorbance steps for each element are calculated. This is done by performing
-    a polynomial fit to the pre-edge absorption (from -200 to -50 eV of specified energy) 
+    a polynomial fit to the pre-edge absorption (from -200 to -60 eV of specified energy) 
     and extrapolating that to the post-edge, then comparing against the actual 
-    computed post-edge absorption.
+    computed post-edge absorption. Thus it is recommended to use an input energy
+    that is the desired edge energy + 50 eV.
 
     Args:
         sample (str or dict): elements/compounds and their mass fractions. one 
                            entry can have value -1 to indicate unspecified portion
-        energy (float): X-ray energy (eV) at which transmission will be analyzed
+        energy (float): X-ray energy (eV) at which transmission will be analyzed.
+                        Recommended to use edge energy + 50 eV.
         absorp_total (float): total absorption (mu_t*d) of the sample at the
                               specified energy
         area (float)(optional): area (cm^2) of the sample. Default is 1 cm^2.
@@ -1166,7 +1168,7 @@ def transmission_sample(sample, energy, absorp_total=2.6, area=1,
     Returns:
         dictionary with fields
 
-            `energy(eV)`        incident energy; recommended to use edge energy + 50 eV
+            `energy(eV)`        incident energy
 
             `absorp_total`      total absorption
 


### PR DESCRIPTION
…polation energy range

Tl;dr Ambiguity in choosing energy input for transmission_sample calculation led to an underestimation of absorbance step (only for some elements). Clarifying recommended energy in docstring and adjusting pre-edge energy interpolation range should clear things up.


Was running some calculations and noticed that I hit a bug (or rather ambiguity) for Co absorbance step calculation, leading to a large underestimation of the Co absorbance step.

The following calculation gives Co absorbance = 0.16, for Co edge energy+50eV:
```python
xraydb.transmission_sample(
    sample={
        'Si': 1,
        'O': 3,
        'Co': 0.2,
        'Fe': 0.2,
    },
    energy=xraydb.xray_edge('Co', 'K').energy+50,
    absorp_total=2.6,
    area=1.33,
    density=None,
    frac_type='molar',
)
```

For this example Co absorbance should actually be 0.89 (cross-checked against XAFSmass). This is fixed by doing Co edge energy+40eV:
```python
res = xraydb.transmission_sample(
    sample={
        'Si': 1,
        'O': 3,
        'Co': 0.2,
        'Fe': 0.2,
    },
    energy=xraydb.xray_edge('Co', 'K').energy+40, # only 40 eV instead of 50 eV
    absorp_total=2.6,
    area=1.33,
    density=None,
    frac_type='molar',
)
```

This is because it seems that `mu_elam('Co', xraydb.xray_edge('Co', 'K').energy)` gives a post-edge value whereas for the other metals (e.g. `mu_elam('Fe', xraydb.xray_edge('Fe', 'K').energy)`) gives pre-edge values.

To remedy, the pre-edge interpolation energy range is changed to start 60eV before the requested energy, and the docstring is updated to indicate the recommended choice of energy to be edge+50eV.
