### PR TITLE
changed namespace of scipy.constants.codata

### DIFF
--- a/python/xraydb/utils.py
+++ b/python/xraydb/utils.py
@@ -24,7 +24,7 @@ PLANCK_HC = 1.e10 * consts.Planck * consts.c / QCHARGE
 E_MASS = consts.electron_mass * consts.c**2 / QCHARGE
 
 # classical electron radius in cm
-R_ELECTRON_CM = 100.0 * consts.codata.physical_constants['classical electron radius'][0]
+R_ELECTRON_CM = 100.0 * consts.physical_constants['classical electron radius'][0]
 
 
 SI_PREFIXES = {'f': 1.e-15, 'femto': 1.e-15,


### PR DESCRIPTION
========================================= warnings summary ==========================================
env/lib/python3.10/site-packages/xraydb/utils.py:27
  /Users/damian/Uni/Programming/xaspy-git/xaspy/env/lib/python3.10/site-packages/xraydb/utils.py:27: DeprecationWarning: Please use `physical_constants` from the `scipy.constants` namespace, the `scipy.constants.codata` namespace is deprecated.
    R_ELECTRON_CM = 100.0 * consts.codata.physical_constants['classical electron radius'][0]

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html