### PR TITLE
Fix Lɑ2 line in the poster

### DIFF
--- a/poster/elines.tex
+++ b/poster/elines.tex
@@ -39,7 +39,7 @@
 
        % l3 lines
        \draw[xray, draw=black!05, fill=black!05] (35mm,   82mm)  -- node[sieg] {$L_l$}          (35mm,  62mm)  -- node[frac] {0.003}  (35mm,  50mm) ;
-       \draw[xray, draw=black!10, fill=black!10] (50mm,   92mm)  -- node[sieg] {$L_{\alpha_2}$}  (50mm,  64mm)  -- node[frac] {0.09}  (50mm,  50mm) ;
+       \draw[xray, draw=black!10, fill=black!10] (50mm,   97mm)  -- node[sieg] {$L_{\alpha_2}$}  (50mm,  64mm)  -- node[frac] {0.09}  (50mm,  50mm) ;
        \draw[xray, draw=black!90, fill=black!90] (65mm,  102mm)  -- node[sieg] {$L_{\alpha_1}$}  (65mm,  69mm)  -- node[frac] {0.80}  (65mm,  50mm) ;
 
        \draw[xjoin, draw=black!20, fill=black!20](75mm, 142mm) -- (80mm, 135mm){};


### PR DESCRIPTION
The starting point should be M4 (see https://xdb.lbl.gov/Section1/Sec_1-2.html).